### PR TITLE
BAH-4805|Update test data for CEIL version upgrade — fix concept UUID…

### DIFF
--- a/src/utils/openmrs-setup.ts
+++ b/src/utils/openmrs-setup.ts
@@ -748,7 +748,7 @@ async function setupConcepts(baseUrl: string): Promise<void> {
     },
     {
       envKey: 'LAB_CONCEPT_PLATELET_COUNT',
-      cielUuid: '159896AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      cielUuid: '729AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
       searchName: 'Platelet count',
       matchName: 'platelet count',
     },
@@ -761,13 +761,13 @@ async function setupConcepts(baseUrl: string): Promise<void> {
     {
       envKey: 'LAB_CONCEPT_ABSOLUTE_IMMATURE_CELL_COUNT',
       cielUuid: '1335AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-      searchName: 'Absolute reticulocyte',
-      matchName: 'absolute',
+      searchName: 'Absolute immature cell count',
+      matchName: 'absolute immature cell count',
     },
     {
       envKey: 'LAB_CONCEPT_COMPLETE_BLOOD_COUNT',
-      cielUuid: '1019AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-      searchName: 'Complete blood count',
+      cielUuid: '163700AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      searchName: 'CBC with differential',
       matchName: 'complete blood count',
     },
     {

--- a/test-data/api/constants.ts
+++ b/test-data/api/constants.ts
@@ -184,7 +184,7 @@ export const CONDITION_CODES = {
 export const FHIR_CODED_VALUES = {
   fever: { code: env('CODED_VALUE_FEVER'), display: 'Fever' },
   hours: { code: env('CODED_VALUE_HOURS'), display: 'Hours' },
-  sitting: { code: env('CODED_VALUE_SITTING'), display: 'sitting' },
+  sitting: { code: env('CODED_VALUE_SITTING'), display: 'Sitting' },
   cephalic: { code: env('CODED_VALUE_CEPHALIC'), display: 'Cephalic' },
 };
 

--- a/test-data/api/diagnosticReportPayload.ts
+++ b/test-data/api/diagnosticReportPayload.ts
@@ -183,7 +183,7 @@ export function buildCompleteBloodCountDRBundle(
     drEntry(
       'dr-cbc',
       serviceRequestId,
-      '1019AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      '163700AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
       'Complete blood count',
       patientRef,
       `Encounter/${encounterUuid}`,


### PR DESCRIPTION
Update test data and concept mappings to support CEIL version upgrade in LOCAL OpenMRS environment.
openmrs-setup.ts: Updated concept UUIDs and search names for:
  - Absolute immature cell count (1335, search: "Absolute immature cell count")
  - Complete blood count (163700, search: "CBC with differential")
  - Platelet count (729)

- diagnosticReportPayload.ts: Updated CBC UUID from 1019 to 163700

- constants.ts: Fixed FHIR coded value display from 'sitting' to 'Sitting'
