### PR TITLE
BAH-4623 | Add patient documents page tests

### DIFF
--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -1,0 +1,9 @@
+import js from "@eslint/js";
+import globals from "globals";
+import tseslint from "typescript-eslint";
+import { defineConfig } from "eslint/config";
+
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: globals.browser } },
+  tseslint.configs.recommended,
+]);

--- a/src/ui/actions/ActionFactory.ts
+++ b/src/ui/actions/ActionFactory.ts
@@ -3,17 +3,20 @@ import { AuthActions } from './authActions';
 import { RegistrationActions } from './registrationActions';
 import { ClinicalActions } from './clinicalActions';
 import { ObservationActions } from './observationActions';
+import { DocumentActions } from './documentActions';
 
 export class ActionFactory {
   readonly auth: AuthActions;
   readonly registration: RegistrationActions;
   readonly clinical: ClinicalActions;
   readonly observation: ObservationActions;
+  readonly document: DocumentActions;
 
   constructor(pageFactory: PageFactory) {
     this.auth = new AuthActions(pageFactory);
     this.registration = new RegistrationActions(pageFactory);
     this.clinical = new ClinicalActions(pageFactory);
     this.observation = new ObservationActions(pageFactory);
+    this.document = new DocumentActions(pageFactory);
   }
 }

--- a/src/ui/actions/documentActions.ts
+++ b/src/ui/actions/documentActions.ts
@@ -1,0 +1,35 @@
+import { expect } from '@playwright/test';
+import { PageFactory } from '../pages/PageFactory';
+
+export class DocumentActions {
+  constructor(private readonly bahmni: PageFactory) {}
+
+  async navigateToPatientDocumentsPage(patientUuid: string) {
+    await this.bahmni.patientDocumentsPage.goto(patientUuid);
+  }
+
+  async uploadDocumentForVisit(visitLabel: string, filePath: string) {
+    await this.bahmni.patientDocumentsPage.expandVisit(visitLabel);
+    await this.bahmni.patientDocumentsPage.uploadDocument(visitLabel, filePath);
+  }
+
+  async verifyDocumentDisplayedForVisit(visitLabel: string, documentType: string) {
+    await this.bahmni.patientDocumentsPage.expandVisit(visitLabel);
+    const documentTypes = await this.bahmni.patientDocumentsPage.getDocumentTypesForVisit(visitLabel);
+    expect(documentTypes).toContainEqual(documentType);
+  }
+
+  async openDocumentAndVerifyViewer(visitLabel: string, documentType: string) {
+    await this.bahmni.patientDocumentsPage.openDocument(visitLabel, documentType);
+    const imageSrc = await this.bahmni.patientDocumentsPage.getViewerImageSrc();
+    expect(imageSrc).toBeTruthy();
+    await this.bahmni.patientDocumentsPage.closeViewer();
+  }
+
+  async verifyPatientDetailsDisplayed(patientName: string, identifier: string) {
+    const displayedName = await this.bahmni.patientDocumentsPage.getPatientName();
+    expect(displayedName).toBe(patientName);
+    const displayedIdentifier = await this.bahmni.patientDocumentsPage.getPatientIdentifier();
+    expect(displayedIdentifier).toBe(identifier);
+  }
+}

--- a/src/ui/fixtures/documentFixture.ts
+++ b/src/ui/fixtures/documentFixture.ts
@@ -10,6 +10,7 @@ type DocumentFixtures = {
     bahmni: PageFactory;
     actions: ActionFactory;
     page: Page;
+    patientUuid: string;
   };
 };
 
@@ -41,7 +42,7 @@ export const test = base.extend<DocumentFixtures>({
       await documentApi.uploadAndRegisterDocuments(patientUuid, DOCUMENTS_TO_UPLOAD);
     });
 
-    await use({ bahmni: ctx.bahmni, actions: ctx.actions, page: ctx.page });
+    await use({ bahmni: ctx.bahmni, actions: ctx.actions, page: ctx.page, patientUuid: ctx.patientUuid });
 
     await disposeSharedClinicalContext(ctx);
   },

--- a/src/ui/pages/patientDocumentsPage.ts
+++ b/src/ui/pages/patientDocumentsPage.ts
@@ -1,4 +1,5 @@
 import { Page, expect } from '@playwright/test';
+import { config } from '../../config/env.config';
 
 export class PatientDocumentsPage {
   private readonly page: Page;
@@ -7,6 +8,23 @@ export class PatientDocumentsPage {
     sideNavLink: 'a:has-text("Patient Documents")',
     documentsTable: 'table[aria-label="Patient Documents"]',
     viewAttachmentLink: 'View attachment/s',
+    // Standalone /bahmni-v2/patient-documents/{uuid} page
+    patientName: '[data-testid="patient-name"]',
+    patientIdentifierRow: 'p:has([aria-label="id-card"])',
+    patientGenderRow: 'p:has([aria-label="gender"])',
+    patientAgeRow: 'p:has([aria-label="age"])',
+    documentsSection: 'section[aria-label="Documents"]',
+    visitAccordionItem: '.cds--accordion__item',
+    visitAccordionHeading: '.cds--accordion__heading',
+    visitAccordionTitle: '.cds--accordion__title',
+    documentRow: '[class*="docRow"]',
+    documentTypeCell: '[class*="typeCell"]',
+    documentTypeLabel: '.cds--list-box__label',
+    documentThumbnailButton: 'button[data-testid$="-test-id"]',
+    uploadFileInput: '[data-testid="document-file-input"]',
+    viewerModal: '#modalIdForActionAreaLayout',
+    viewerModalImage: '[data-testid$="-modal-image-test-id"]',
+    viewerModalCloseButton: 'button[aria-label="Close"]',
   } as const;
 
   constructor(page: Page) {
@@ -40,5 +58,89 @@ export class PatientDocumentsPage {
     for (let i = 1; i <= totalDocuments; i++) {
       await expect(dialog.getByText(`${i}/${totalDocuments}`)).toBeVisible();
     }
+  }
+
+  // Standalone /bahmni-v2/patient-documents/{uuid} page
+
+  async goto(patientUuid: string) {
+    await this.page.goto(`${config.baseUrl}/bahmni-v2/patient-documents/${patientUuid}`);
+    await this.page.waitForLoadState('networkidle', { timeout: 20000 });
+  }
+
+  private getVisitAccordionItem(visitLabel: string) {
+    return this.page.locator(this.selectors.visitAccordionItem).filter({ hasText: visitLabel });
+  }
+
+  private getDocumentRow(visitLabel: string, documentType: string) {
+    return this.getVisitAccordionItem(visitLabel).locator(this.selectors.documentRow).filter({ hasText: documentType });
+  }
+
+  async getPatientName(): Promise<string> {
+    return (await this.page.locator(this.selectors.patientName).textContent())?.trim() ?? '';
+  }
+
+  async getPatientIdentifier(): Promise<string> {
+    return (
+      (await this.page.locator(this.selectors.patientIdentifierRow).locator('span').last().textContent())?.trim() ?? ''
+    );
+  }
+
+  async getPatientGender(): Promise<string> {
+    return (
+      (await this.page.locator(this.selectors.patientGenderRow).locator('span').last().textContent())?.trim() ?? ''
+    );
+  }
+
+  async getPatientAge(): Promise<string> {
+    return (await this.page.locator(this.selectors.patientAgeRow).locator('span').last().textContent())?.trim() ?? '';
+  }
+
+  async getVisitLabels(): Promise<string[]> {
+    return this.page.locator(this.selectors.visitAccordionTitle).allTextContents();
+  }
+
+  async expandVisit(visitLabel: string) {
+    const heading = this.getVisitAccordionItem(visitLabel).locator(this.selectors.visitAccordionHeading);
+    if ((await heading.getAttribute('aria-expanded')) !== 'true') {
+      await heading.click();
+    }
+  }
+
+  async getDocumentTypesForVisit(visitLabel: string): Promise<string[]> {
+    return this.getVisitAccordionItem(visitLabel)
+      .locator(this.selectors.documentTypeCell)
+      .locator(this.selectors.documentTypeLabel)
+      .allTextContents();
+  }
+
+  async openDocument(visitLabel: string, documentType: string) {
+    const row = this.getDocumentRow(visitLabel, documentType);
+    await row.waitFor({ state: 'visible', timeout: 10000 });
+    await row.locator(this.selectors.documentThumbnailButton).click();
+  }
+
+  async getViewerImageSrc(): Promise<string | null> {
+    const modal = this.page.locator(this.selectors.viewerModal);
+    await modal.waitFor({ state: 'visible', timeout: 10000 });
+    return modal.locator(this.selectors.viewerModalImage).getAttribute('src');
+  }
+
+  async closeViewer() {
+    const modal = this.page.locator(this.selectors.viewerModal);
+    await modal.locator(this.selectors.viewerModalCloseButton).click();
+    await modal.waitFor({ state: 'hidden', timeout: 10000 });
+  }
+
+  /**
+   * Selecting a file renders a pending row (thumbnail + document-type combobox,
+   * defaulted from the file name) that must be confirmed with Save before it
+   * appears in the documents table.
+   */
+  async uploadDocument(visitLabel: string, filePath: string) {
+    const item = this.getVisitAccordionItem(visitLabel);
+    await item.locator(this.selectors.uploadFileInput).setInputFiles(filePath);
+    const saveButton = item.getByRole('button', { name: 'Save' });
+    await saveButton.waitFor({ state: 'visible', timeout: 10000 });
+    await saveButton.click();
   }
 }

--- a/src/utils/openmrs-setup.ts
+++ b/src/utils/openmrs-setup.ts
@@ -963,6 +963,24 @@ async function setupConcepts(baseUrl: string): Promise<void> {
       searchName: 'Anaemia',
       matchName: 'anaemia',
     },
+    {
+      envKey: 'CONDITION_CODE_DENGUE',
+      cielUuid: '142592AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      searchName: 'Dengue fever',
+      matchName: 'dengue fever',
+    },
+    {
+      envKey: 'CONDITION_CODE_TETANUS',
+      cielUuid: '124957AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      searchName: 'Tetanus',
+      matchName: 'tetanus',
+    },
+    {
+      envKey: 'CONDITION_CODE_TYPHOID_FEVER',
+      cielUuid: '141AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      searchName: 'Typhoid fever',
+      matchName: 'typhoid fever',
+    },
     // FHIR coded values
     {
       envKey: 'CODED_VALUE_FEVER',

--- a/tests/ui/module/clinical/patientDocuments.spec.ts
+++ b/tests/ui/module/clinical/patientDocuments.spec.ts
@@ -15,4 +15,20 @@ test.describe('Patient Document Tests', { tag: ['@regression'] }, () => {
     await bahmni.patientDocumentsPage.openAttachment(DOCUMENT_IDENTIFIER);
     await bahmni.patientDocumentsPage.verifyAllAttachmentsDisplayed(TOTAL_DOCUMENTS);
   });
+
+  test('Upload a document via the standalone patient-documents page and view it', async ({ documentSetup }) => {
+    const { bahmni, actions, page, patientUuid } = documentSetup;
+    const uploadFilePath = 'test-data/common/prescription.png';
+    const uploadedDocumentType = 'Prescription';
+
+    await actions.document.navigateToPatientDocumentsPage(patientUuid);
+    await expect(page).toHaveURL(new RegExp(`patient-documents/${patientUuid}`));
+
+    const visitLabels = await bahmni.patientDocumentsPage.getVisitLabels();
+    const visitLabel = visitLabels[0];
+
+    await actions.document.uploadDocumentForVisit(visitLabel, uploadFilePath);
+    await actions.document.verifyDocumentDisplayedForVisit(visitLabel, uploadedDocumentType);
+    await actions.document.openDocumentAndVerifyViewer(visitLabel, uploadedDocumentType);
+  });
 });


### PR DESCRIPTION
## Summary
- Add `documentActions.ts` and `patientDocumentsPage.ts` coverage for uploading, viewing, and verifying patient documents.
- Add `patientDocuments.spec.ts` test cases exercising the new page object/actions.
- Extend `documentFixture.ts` to expose `patientUuid` for use in the new tests, and register the new actions in `ActionFactory.ts`.
- Add condition codes (Dengue fever, Tetanus, Typhoid fever) to `openmrs-setup.ts`.
- Add `eslint.config.mts`.

## Test plan
- [ ] Run `npx playwright test tests/ui/module/clinical/patientDocuments.spec.ts` against a dev environment
- [ ] Verify document upload, viewer, and patient details assertions pass